### PR TITLE
Add plugin targets.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Plugins are organized by section and ordered alphabetically.
 * [Sneak](https://github.com/justinmk/vim-sneak)
 * [Surround](https://github.com/tpope/vim-surround)
 * [Tabular](https://github.com/godlygeek/tabular)
+* [Targets](https://github.com/wellle/targets.vim)
 * [TComment](https://github.com/tomtom/tcomment_vim)
 * [TextobjIndent](https://github.com/kana/vim-textobj-indent)
 * [TextobjUser](https://github.com/kana/vim-textobj-user)


### PR DESCRIPTION
Add one of my plugins, [targets.vim](https://github.com/wellle/targets.vim).

--
On an different note: I have another plugin [tmux-complete.vim](https://github.com/wellle/tmux-complete.vim) which might also be awesome enough to make it to this list. But I'm not sure if we already have a category where it would fit. It integrates Vim with tmux for insert mode completion.

Would you consider adding it if I open a separate PR? If so, in what category may I put it?

Thanks for being awesome :+1:

--
Edit: Category `Syntax/Completion` would probably be best.