### PR TITLE
Add vim-lastplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Plugins are organized by section and ordered alphabetically.
 
 * [Airline](https://github.com/bling/vim-airline)
 * [Signify](https://github.com/mhinz/vim-signify)
+* [vim-lastplace](https://github.com/dietsche/vim-lastplace)
 
 ### Searching
 


### PR DESCRIPTION
It's awesome, because it just works. There is no thinking about how to use this plugin. Just install it, and boom, when you open a file it opens exactly where you left off last time. There are many other ways of doing this on the web, but none work as well as this one and none are as carefully thought out. This plugin is configurable so that it knows not to jump to the last edit position for specific file types such as commit messages. This feature ensures that the plugin never annoys and always delights!