### PR TITLE
Added PieCrumbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Plugins are organized by section and ordered alphabetically.
 ### Python
 
 * [PythonMode](https://github.com/klen/python-mode)
+* [PieCrumbs](https://github.com/and3rson/piecrumbs)
 
 ### Ruby
 


### PR DESCRIPTION
This plugin displays current location in Python classes/methods.

![Screenshot](https://github.com/and3rson/piecrumbs/raw/master/piecrumbs.png)

Useful for seeing where the hell you are right now.

- Why don't you use tags in sidebar?
- I wanted a more lightweight thing and that is why I wrote this plugin.
