### PR TITLE
add vim-jumparound

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Plugins are organized by section and ordered alphabetically.
 * [ExpandRegion](https://github.com/terryma/vim-expand-region)
 * [Gundo](https://github.com/sjl/gundo.vim)
 * [IndentGuides](https://github.com/nathanaelkane/vim-indent-guides)
+* [Jumparound](https://github.com/suewonjp/vim-jumparound)
 * [NerdCommenter](https://github.com/scrooloose/nerdcommenter)
 * [Repeat](https://github.com/tpope/vim-repeat)
 * [Sneak](https://github.com/justinmk/vim-sneak)


### PR DESCRIPTION
https://github.com/suewonjp/vim-jumparound

**Jumparound** is a plugin for quickly jumping around your content:

It provides mappings and commands for:

- Quick Jump between Tab Pages/Windows/Marks
- Quick Text Search
- Easy Use of Quickfix List
- Quick Invocation of File Explorer
- Etc.