### PR TITLE
Added: Doctor - a quick reference for Vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Plugins organized by section and ordered alphabetically.
 * [Vim Tips](http://zzapper.co.uk/vimtips.html)
 * [Fortune vimtips](https://github.com/hobbestigrou/vimtips-fortune)
 * [Vim Galore](https://github.com/mhinz/vim-galore)
+* [Doctor](https://github.com/p1v0t/Doctor)
 
 
 ## Plugin Management


### PR DESCRIPTION
Doctor is yet another quick reference for Vim text editor which gives concise instructions on usage, adding plugin, installing, building from source as well as useful links. 