### PR TITLE
Add vim-diminactive to Interface section

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Plugins organized by section and ordered alphabetically.
 ### Interface
 
 * [Airline](https://github.com/bling/vim-airline) + [Airline Themes](https://github.com/vim-airline/vim-airline-themes)
+* [vim-diminactive](https://github.com/blueyed/vim-diminactive)
 * [vim-lastplace](https://github.com/farmergreg/vim-lastplace)
 * [Signify](https://github.com/mhinz/vim-signify)
 * [Startify](https://github.com/mhinz/vim-startify)


### PR DESCRIPTION
## Notable changes

- Added the **vim-diminactive** plugin to the list under the Interface category.

## Reason

I believe the **vim-diminactive** plugin is awesome because it lets you dim the inactive panes in and gets you to focus on the pane you are writing code inside of. It creates more structure in the workflow and limits distractions in your coding and text-editing.

## Examples

[![asciicast](https://asciinema.org/a/13855.png)](https://asciinema.org/a/13855)