### PR TITLE
adding markdown-drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Plugins organized by section and ordered alphabetically.
 ### Markdown
 
 * [vim-instant-markdown](https://github.com/suan/vim-instant-markdown)
+* [markdown-drawer](https://github.com/Scuilion/markdown-drawer)
 * [vim-markdown-toc](https://github.com/mzlogin/vim-markdown-toc)
 
 ### PHP


### PR DESCRIPTION
Markdown Drawer is awesome because it allows you to not only quickly navigate markdown but also rearrange your document by the header. Great for people who do large documentation in markdown.