### PR TITLE
Add zoxide.vim under Search Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ Plugins organized by section and ordered alphabetically.
 * [CtrlSF](https://github.com/dyng/ctrlsf.vim)
 * [FlyGrep](https://github.com/wsdjeg/FlyGrep.vim)
 * [fzf](https://github.com/junegunn/fzf#as-vim-pluginc) ([highly recommended](https://github.com/junegunn/fzf#tips) to use [fd](https://github.com/sharkdp/fd) and [ripgrep](https://github.com/BurntSushi/ripgrep))
-* [vim-codequery](https://github.com/devjoe/vim-codequery)
 * [MRU](https://github.com/yegappan/mru)
+* [vim-codequery](https://github.com/devjoe/vim-codequery)
+* [zoxide.vim](https://github.com/nanotee/zoxide.vim)
 
 ### Task Running
 


### PR DESCRIPTION
[zoxide.vim](https://github.com/nanotee/zoxide.vim) is a smarter cd command for vim -- it helps you quickly navigate to any directory on your filesystem.