### PR TITLE
Add Surround-Funk plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Plugins organized by section and ordered alphabetically.
 * [NerdCommenter](https://github.com/scrooloose/nerdcommenter)
 * [Repeat](https://github.com/tpope/vim-repeat)
 * [Surround](https://github.com/tpope/vim-surround)
+* [Surround-funk](https://github.com/Matt-A-Bennett/surround-funk.vim)
 * [Tabular](https://github.com/godlygeek/tabular)
 * [Targets](https://github.com/wellle/targets.vim)
 * [TComment](https://github.com/tomtom/tcomment_vim)


### PR DESCRIPTION
This plugin was inspired by tpope's surround.vim and allows you to delete, change and yank a surrounding function along with its additional arguments. With the surrounding function in the unnamed register, you can 'grip' a word or another function with it. 'Gripping' will wrap/encompass a word or function with the one you have in the unnamed register.