### PR TITLE
Add Fuzzbox under Search Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Plugins organized by section and ordered alphabetically.
 * [CtrlSF](https://github.com/dyng/ctrlsf.vim)
 * [FlyGrep](https://github.com/wsdjeg/FlyGrep.vim)
 * [fzf](https://github.com/junegunn/fzf#as-vim-pluginc) ([highly recommended](https://github.com/junegunn/fzf#tips) to use [fd](https://github.com/sharkdp/fd) and [ripgrep](https://github.com/BurntSushi/ripgrep))
+* [Fuzzbox](https://github.com/vim-fuzzbox/fuzzbox.vim)
 * [MRU](https://github.com/yegappan/mru)
 * [vim-codequery](https://github.com/devjoe/vim-codequery)
 * [zoxide.vim](https://github.com/nanotee/zoxide.vim)


### PR DESCRIPTION
Fuzzbox is a Vim9 fuzzy finder, with minimal dependencies that just works (on Vim 9) as it relies on native Vim fuzzy matching functions and vim9script rather than external commands or language interpreters.

It will use pre-installed programs on Unix and Windows systems for finding files and live grep (e.g. find and grep), but will also use better tools if they are available (e.g. fd, git-ls-files, ripgrep).